### PR TITLE
Load map tiles from HTTPS CDN

### DIFF
--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -29,7 +29,7 @@
             var marker = L.marker([59.91913736963502,10.75211763381958]).addTo(mymap);
             mymap.scrollWheelZoom.disable();
             marker.bindPopup("<b>Hausmania</b><br>Hausmannsgate 34.");
-                 L.tileLayer('//tile.stamen.com/toner/{z}/{x}/{y}.png', {
+                 L.tileLayer('https://stamen-tiles.a.ssl.fastly.net/toner/{z}/{x}/{y}.png', {
                  attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
                 maxZoom: 18,
                 }).addTo(mymap);


### PR DESCRIPTION
Original tiles CDN doesn't have a valid SSL cert.
Proxying these requests ourselves will solve this issue.

With correct configuration, will resolve #15 