### PR TITLE
Add hash link on logo link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
   <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarMain" aria-controls="navbarMain" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <a class="navbar-brand" href="{{ "/" | absolute_url }}">
+  <a class="navbar-brand" href="/#top">
     <img src="{{ "assets/img/logo.png" | relative_url }}" alt="Hausmania logo">
     <span>Hausmania</span>
   </a>


### PR DESCRIPTION
Avoids reloading the page if already on index; instead scrolls to top.

Fixes #23 